### PR TITLE
fix: update SSH key format in CD workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Add host key
+      - name: Install SSH key
         run: |
           mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H ${{ secrets.SERVER_IP }} >> ~/.ssh/known_hosts
 
       - name: Deploy to server
@@ -27,4 +24,4 @@ jobs:
           SERVER_IP: ${{ secrets.SERVER_IP }}
           SERVER_USER: ${{ secrets.SERVER_USER }}
         run: |
-          ssh $SERVER_USER@$SERVER_IP 'cd ~/hng-stage2-task-fastapi && git pull origin main && source venv/bin/activate && pip install -r requirements.txt && sudo systemctl restart fastapi'
+          ssh -i ~/.ssh/id_ed25519 $SERVER_USER@$SERVER_IP 'cd ~/hng-stage2-task-fastapi && git pull origin main && source venv/bin/activate && pip install -r requirements.txt && sudo systemctl restart fastapi'

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+fastapi-book-app-key.pem


### PR DESCRIPTION
## Changes
- Remove webfactory/ssh-agent action in favor of direct SSH key installation
- Add secure key file permissions (chmod 600)
- Update SSH command to use ED25519 key format
- Maintain all existing deployment functionality

## Testing
- [ ] Update SSH_PRIVATE_KEY secret in GitHub with the new ED25519 format
- [ ] Verify SSH connection to EC2 instance
- [ ] Test automatic deployment on merge to main

## Security
- Ensures proper key file permissions
- Uses modern ED25519 key format
- Maintains secure key handling practices

## Related
Fixes SSH key format issues in CD pipeline